### PR TITLE
`passportStub.uninstall()` に不要な `app` 引数を削除

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -16,7 +16,7 @@ describe('/login', () => {
 
   afterAll(() => {
     passportStub.logout();
-    passportStub.uninstall(app);
+    passportStub.uninstall();
   });
 
   test('ログインのためのリンクが含まれる', async () => {
@@ -53,7 +53,7 @@ describe('/schedules', () => {
 
   afterAll(async () => {
     passportStub.logout();
-    passportStub.uninstall(app);
+    passportStub.uninstall();
     await deleteScheduleAggregate(scheduleId);
   });
 
@@ -92,7 +92,7 @@ describe('/schedules/:scheduleId/users/:userId/candidates/:candidateId', () => {
 
   afterAll(async () => {
     passportStub.logout();
-    passportStub.uninstall(app);
+    passportStub.uninstall();
     await deleteScheduleAggregate(scheduleId);
   });
 
@@ -129,7 +129,7 @@ describe('/schedules/:scheduleId/users/:userId/comments', () => {
 
   afterAll(async () => {
     passportStub.logout();
-    passportStub.uninstall(app);
+    passportStub.uninstall();
     await deleteScheduleAggregate(scheduleId);
   });
 


### PR DESCRIPTION
`passportStub.uninstall()` に不要な `app` 引数を削除しました
（ https://github.com/nnn-training/change-repo-contents-all を使って作成しました）